### PR TITLE
Wait a bit after running a script

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,5 @@
+coffee_script:
+  config_file: coffeelint.json
+
+java_script:
+  enabled: false

--- a/build/diskpart.js
+++ b/build/diskpart.js
@@ -34,6 +34,10 @@ exports.runScript = function(scriptPath, callback) {
       return callback();
     }, function(callback) {
       return helpers.execute("diskpart /s \"" + scriptPath + "\"", callback);
+    }, function(output, callback) {
+      return setTimeout(function() {
+        return callback(null, output);
+      }, 2000);
     }
   ], callback);
 };

--- a/lib/diskpart.coffee
+++ b/lib/diskpart.coffee
@@ -33,6 +33,15 @@ exports.runScript = (scriptPath, callback) ->
 		(callback) ->
 			helpers.execute("diskpart /s \"#{scriptPath}\"", callback)
 
+		(output, callback) ->
+
+			# Windows needs some time after the diskpart script
+			# is executed to reflect the changes.
+			# This mainly happened in Windows 10.
+			# An empirically derivated value that seems to be enough is 2s.
+			setTimeout ->
+				return callback(null, output)
+			, 2000
 	], callback)
 
 exports.evaluate = (input, callback) ->

--- a/tests/diskpart.spec.coffee
+++ b/tests/diskpart.spec.coffee
@@ -39,6 +39,7 @@ describe 'Diskpart:', ->
 				@helpersExecuteStub.restore()
 
 			it 'should call helpers.execute with the correct arguments', (done) ->
+				@timeout(5000)
 				diskpart.runScript 'myScript', (error, output) =>
 					expect(error).to.not.exist
 					expect(output).to.equal('Hello World')
@@ -119,6 +120,7 @@ describe 'Diskpart:', ->
 			# after execution.
 
 			it 'should call helpers.execute', (done) ->
+				@timeout(5000)
 				diskpart.evaluate [ 'rescan' ], (error, output) =>
 					expect(error).to.not.exist
 					expect(output).to.equal('Hello World')


### PR DESCRIPTION
Windows needs some time after the diskpart script is executed to reflect the changes.  This mainly happened in Windows 10.

An empirically derivated value that seems to be enough is 2s.
